### PR TITLE
use alternate omniauth config for cas inline with lti

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,8 @@
   gem 'equivalent-xml'
   gem 'net-ldap'
 
+  gem 'omniauth-cas'
+
   group :assets, :production do
     gem 'coffee-rails'
     gem 'uglifier', '>= 1.0.3'

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -69,7 +69,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     elsif auth_type == 'lti' && user_session[:virtual_groups].present?
       redirect_to catalog_index_path('f[read_access_virtual_group_ssim][]' => user_session[:lti_group])
     else
-      redirect_to root_url
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,10 +22,11 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def destroy
-    logger.info "logout of #{Avalon::Authentication::VisibleProviders.first[:provider]}"
+    logger.info "logout of #{Avalon::Authentication::VisibleProviders.first[:provider]} for #{current_user.inspect}"
     if Avalon::Authentication::VisibleProviders.first[:provider] == :cas
+      StreamToken.logout! session
       sign_out(current_user)
-      redirect_to 'https://secure.its.yale.edu/cas/logout' and return
+      redirect_to 'https://secure.its.yale.edu/cas/logout'
     else
       StreamToken.logout! session
       super

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,9 +22,15 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def destroy
-    StreamToken.logout! session
-    super
-    flash[:success] = flash[:notice]
-    flash[:notice] = nil
+    logger.info "logout of #{Avalon::Authentication::VisibleProviders.first[:provider]}"
+    if Avalon::Authentication::VisibleProviders.first[:provider] == :cas
+      sign_out(current_user)
+      redirect_to 'https://secure.its.yale.edu/cas/logout' and return
+    else
+      StreamToken.logout! session
+      super
+      flash[:success] = flash[:notice]
+      flash[:notice] = nil
+    end
   end
 end


### PR DESCRIPTION
use config.authentication.yml
- :name: Avalon Yale CAS OAuth
  :provider: :cas
  :params:
    host: secure.its.yale.edu
    login_url: /cas/login
    logout_url: /cas/logout
    service_validate_url: /cas/serviceValidate
    disable_ssl_verification: true
